### PR TITLE
Pick the latest sources from lib_wallet submodule

### DIFF
--- a/auto-build/ubuntu-18.04/compile.sh
+++ b/auto-build/ubuntu-18.04/compile.sh
@@ -23,6 +23,9 @@ add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y
 MAKE_THREADS_CNT=-j8
 
 git clone --recursive https://github.com/newton-blockchain/wallet-desktop.git
+cd wallet-desktop
+git submodule update --remote Wallet/lib_wallet
+cd ..
 
 mkdir Libraries
 cd Libraries

--- a/auto-build/windows10/compile.bat
+++ b/auto-build/windows10/compile.bat
@@ -122,6 +122,10 @@ cmake --build . --target tonlib --config Release
 cd %LibrariesPath%\..
 git clone --recursive https://github.com/newton-blockchain/wallet-desktop.git
 
+cd wallet-desktop
+git submodule update --remote Wallet/lib_wallet
+cd ..
+
 cd wallet-desktop\Wallet
 python --version
 call configure.bat -D DESKTOP_APP_USE_PACKAGED=OFF


### PR DESCRIPTION
After breaking the link with original lib_wallet repo, we want to take changes after revision point that was linked originally.